### PR TITLE
Add cloudfront invalidation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,16 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           SOURCE_DIR: 'dist/expert-consultation-client'
 
+      - name: Create cloudfront invalidation
+        if: github.ref == 'refs/heads/develop'
+        uses: awact/cloudfront-action@master
+        env:
+          SOURCE_PATH: './*'
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          DISTRIBUTION_ID: ${{ secrets.DISTRIBUTION_ID }}
+
       - name: Build the Docker image
         if: github.ref == 'refs/heads/develop'
         run: |


### PR DESCRIPTION
When the automatic build is deployed, we also need to create an invalidation in cloudfront.