### PR TITLE
Fixed: Article title is not shown in document view

### DIFF
--- a/src/app/documents/components/document-node/document-node-article/document-node-article.component.html
+++ b/src/app/documents/components/document-node/document-node-article/document-node-article.component.html
@@ -4,7 +4,7 @@
       class="fa fa-edit"></i></span>
     <strong>
       {{'document.view.section.type.article' | translate}}
-      {{article.identifier}}
+      {{article.identifier + (article.title ? ': ' + article.title : '')}}
     </strong>
     <p>{{article.content}}</p>
   </div>


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
Fixes article title not being shown in the document view.

Closes #145

Added the article title next to the identifier.

### How has it been tested?

Tested on different types on documents.

